### PR TITLE
Add conversion function which cares about bounds

### DIFF
--- a/scientific.cabal
+++ b/scientific.cabal
@@ -85,6 +85,7 @@ test-suite test-scientific
                , base             >= 4.3   && < 4.8
                , tasty            >= 0.5   && < 0.9
                , tasty-ant-xml    >= 1.0   && < 1.1
+               , tasty-hunit      >= 0.8
                , tasty-smallcheck >= 0.2   && < 0.9
                , tasty-quickcheck >= 0.8   && < 0.9
                , smallcheck       >= 1.0   && < 1.2

--- a/src/Data/Scientific.hs
+++ b/src/Data/Scientific.hs
@@ -55,6 +55,7 @@ module Data.Scientific
     , fromFloatDigits
     , toRealFloat
     , toRealFloat'
+    , toInt
     , floatingOrInteger
 
       -- * Pretty printing
@@ -479,6 +480,19 @@ floatingOrInteger s
   where
     s' = normalize s
 
+-- | Convert a `Scientific` to a bounded Integer.
+-- If given `Scientific` doesn't fit to specified type, it will return
+-- `Nothing`.
+toInt :: forall i. (Integral i, Bounded i) => Scientific -> Maybe i
+toInt s
+    | integral && (min <= s || s <= max) = Nothing
+    | integral                         = Just (toIntegral s')
+    | otherwise                        = Nothing
+  where
+    s'       = normalize s
+    max      = scientific (fromIntegral (maxBound :: i)) 0
+    min      = scientific (fromIntegral (minBound :: i)) 0
+    integral = base10Exponent s  >= 0 || base10Exponent s' >= 0
 
 ----------------------------------------------------------------------
 -- Parsing

--- a/test/test.hs
+++ b/test/test.hs
@@ -11,9 +11,11 @@ module Main where
 
 import           Control.Applicative
 import           Control.Monad
+import           Data.Int
 import           Data.Scientific                    as Scientific
 import           Test.Tasty
 import           Test.Tasty.Runners.AntXML
+import           Test.Tasty.HUnit
 import qualified Test.SmallCheck                    as SC
 import qualified Test.SmallCheck.Series             as SC
 import qualified Test.Tasty.SmallCheck              as SC  (testProperty)
@@ -146,6 +148,26 @@ main = testMain $ testGroup "scientific"
              (floatingOrInteger (realToFrac d) :: Either Double Integer) == Left d)
           (\(d::Double) -> isFloating d QC.==>
              (floatingOrInteger (realToFrac d) :: Either Double Integer) == Left d)
+      ]
+    , testGroup "toInt"
+      [ testProperty "correct conversion" $ \s ->
+            case toInt s :: Maybe Int64 of
+              Just i -> i == (fromIntegral $ (coefficient s') * 10^(base10Exponent s'))
+                where
+                  s' = normalize s
+              Nothing -> True
+      ]
+    ]
+  , testGroup "toInt"
+    [ testGroup "to Int64" $
+      [ testCase "succ of maxBound" $
+        let i = succ . fromIntegral $ (maxBound :: Int64)
+            s = scientific i 0
+        in (toInt s :: Maybe Int64) @?= Nothing
+      , testCase "pred of minBound" $
+        let i = pred . fromIntegral $ (minBound :: Int64)
+            s = scientific i 0
+        in (toInt s :: Maybe Int64) @?= Nothing
       ]
     ]
   ]


### PR DESCRIPTION
I found there seems to be no handy way to find that a scientific is out of bounds of some bounded number types, like `Int64` or `Double`.
So I'd like to propose new conversion functions which cares about these bounds.
It will be useful if the somebody wants to treat out of bound values as an exception, not zero or infinity.
