### PR TITLE
Add predicates returning if the scientific is floating or integer

### DIFF
--- a/src/Data/Scientific.hs
+++ b/src/Data/Scientific.hs
@@ -56,6 +56,10 @@ module Data.Scientific
     , toRealFloat
     , floatingOrInteger
 
+      -- * Predicates
+    , isFloating
+    , isInteger
+
       -- * Pretty printing
     , formatScientific
     , FPFormat(..)
@@ -469,6 +473,19 @@ floatingOrInteger s
     | otherwise              = Left  (toRealFloat  s')
   where
     s' = normalize s
+
+
+----------------------------------------------------------------------
+-- Predicates
+----------------------------------------------------------------------
+
+-- | Return 'True' if the scientific is a floating point, 'False' otherwise.
+isFloating :: Scientific -> Bool
+isFloating = not . isInteger
+
+-- | Return 'True' if the scientific is an integer, 'False' otherwise.
+isInteger :: Scientific -> Bool
+isInteger s = base10Exponent s >= 0 || base10Exponent (normalize s) >= 0
 
 
 ----------------------------------------------------------------------

--- a/test/test.hs
+++ b/test/test.hs
@@ -142,20 +142,23 @@ main = testMain $ testGroup "scientific"
       , testProperty "Integer == Right" $ \(i::Integer) ->
           (floatingOrInteger (fromInteger i) :: Either Double Integer) == Right i
       , smallQuick "Double == Left"
-          (\(d::Double) -> isFloating d SC.==>
+          (\(d::Double) -> genericIsFloating d SC.==>
              (floatingOrInteger (realToFrac d) :: Either Double Integer) == Left d)
-          (\(d::Double) -> isFloating d QC.==>
+          (\(d::Double) -> genericIsFloating d QC.==>
              (floatingOrInteger (realToFrac d) :: Either Double Integer) == Left d)
       ]
+    ]
+  , testGroup "Predicates"
+    [ testProperty "isFloating" $ \s -> isFloating s == genericIsFloating s
+    , testProperty "isInteger" $ \s -> isInteger s == not (genericIsFloating s)
     ]
   ]
 
 testMain :: TestTree -> IO ()
 testMain = defaultMainWithIngredients (antXMLRunner:defaultIngredients)
 
-isFloating :: Double -> Bool
-isFloating 0 = False
-isFloating d = fromInteger (floor d :: Integer) /= d
+genericIsFloating :: RealFrac a => a -> Bool
+genericIsFloating a = fromInteger (floor a :: Integer) /= a
 
 conversionsProperties :: forall realFloat.
                          ( RealFloat    realFloat


### PR DESCRIPTION
This would be useful when we need to make decision only based on whether the scientific it's floating point or integer. Especially when `warn-type-defaults` is on, we can write

``` haskell
  if isFloating s then d else i
```

instead of

``` haskell
  either (const d) (const i) (floatingOrInteger s :: Either Double Integer)
```

or

``` haskell
  case floatingOrInteger s of
    Left (_ :: Double) -> d
    Right (_ :: Integer) -> i
```
