### PR TITLE
Add support for `deepseq-1.4`

### DIFF
--- a/scientific.cabal
+++ b/scientific.cabal
@@ -64,9 +64,9 @@ library
   other-modules:       Math.NumberTheory.Logarithms
   other-extensions:    DeriveDataTypeable, BangPatterns
   ghc-options:         -Wall
-  build-depends:       base        >= 4.3   && < 4.8
+  build-depends:       base        >= 4.3   && < 4.9
                      , ghc-prim
-                     , deepseq     >= 1.3   && < 1.4
+                     , deepseq     >= 1.3   && < 1.5
                      , text        >= 0.8   && < 1.3
                      , hashable    >= 1.1.2 && < 1.3
                      , array       >= 0.1   && < 0.6

--- a/src/Data/Scientific.hs
+++ b/src/Data/Scientific.hs
@@ -84,7 +84,7 @@ module Data.Scientific
 ----------------------------------------------------------------------
 
 import           Control.Monad                (mplus)
-import           Control.DeepSeq              (NFData)
+import           Control.DeepSeq              (NFData(rnf))
 import           Data.Array                   (Array, listArray, (!))
 import           Data.Char                    (intToDigit, ord)
 import           Data.Data                    (Data)
@@ -146,7 +146,8 @@ scientific = Scientific
 -- Instances
 ----------------------------------------------------------------------
 
-instance NFData Scientific
+instance NFData Scientific where
+    rnf (Scientific _ _) = ()
 
 instance Hashable Scientific where
     hashWithSalt salt = hashWithSalt salt . toRational


### PR DESCRIPTION
See haskell/deepseq#1 for more details about the changes in `deepseq-1.4`

(and relax build-deps to allow `base-4.8`)
