### PR TITLE
Fix #21

### DIFF
--- a/src/Data/Scientific.hs
+++ b/src/Data/Scientific.hs
@@ -95,7 +95,8 @@ import           Data.Ratio                   ((%), numerator, denominator)
 import           Data.Typeable                (Typeable)
 import           Math.NumberTheory.Logarithms (integerLog10')
 import qualified Numeric                      (floatToDigits)
-import           Text.Read                    (readPrec)
+import qualified Text.Read                       as Read
+import           Text.Read                        (readPrec)
 import qualified Text.ParserCombinators.ReadPrec as ReadPrec
 import qualified Text.ParserCombinators.ReadP    as ReadP
 import           Text.ParserCombinators.ReadP     ( ReadP )
@@ -562,7 +563,7 @@ isInteger s = base10Exponent s  >= 0 ||
 ----------------------------------------------------------------------
 
 instance Read Scientific where
-    readPrec = ReadPrec.lift scientificP
+    readPrec = Read.parens $ ReadPrec.lift (ReadP.skipSpaces >> scientificP)
 
 -- A strict pair
 data SP = SP !Integer {-# UNPACK #-}!Int

--- a/src/Data/Scientific.hs
+++ b/src/Data/Scientific.hs
@@ -584,7 +584,7 @@ scientificP = do
                                  SP (step a digit) (e-1)) s
 
   SP coeff expnt <- (ReadP.satisfy (== '.') >> fractional)
-                      `mplus` return s
+                    ReadP.<++ return s
 
   let signedCoeff | pos       =   coeff
                   | otherwise = (-coeff)

--- a/test/test.hs
+++ b/test/test.hs
@@ -46,10 +46,10 @@ main = testMain $ testGroup "scientific"
   , testGroup "Parsing"
     [ testCase "reads \"\""        $ testReads ""        []
     , testCase "reads \"1.\""      $ testReads "1."      [(1.0, ".")]
-    , testCase "reads \"1.2e\""    $ testReads "1.2e"    [(1.0, ".2e"), (1.2, "e")]
+    , testCase "reads \"1.2e\""    $ testReads "1.2e"    [(1.2, "e")]
     , testCase "reads \"(1.3 )\""  $ testReads "(1.3 )"  [(1.3, "")]
     , testCase "reads \"((1.3))\"" $ testReads "((1.3))" [(1.3, "")]
-    , testCase "reads \" 1.3\""    $ testReads " 1.3"    [(1.0, ".3"), (1.3, "")]
+    , testCase "reads \" 1.3\""    $ testReads " 1.3"    [(1.3, "")]
     ]
 
   , testGroup "Formatting"

--- a/test/test.hs
+++ b/test/test.hs
@@ -44,9 +44,12 @@ main = testMain $ testGroup "scientific"
             s /= 0 QC.==> abs (Scientific.coefficient s) `mod` 10 /= 0)
 
   , testGroup "Parsing"
-    [ testCase "reads \"\""     $ testReads ""     []
-    , testCase "reads \"1.\""   $ testReads "1."   [(1.0, ".")]
-    , testCase "reads \"1.2e\"" $ testReads "1.2e" [(1.0, ".2e"), (1.2, "e")]
+    [ testCase "reads \"\""        $ testReads ""        []
+    , testCase "reads \"1.\""      $ testReads "1."      [(1.0, ".")]
+    , testCase "reads \"1.2e\""    $ testReads "1.2e"    [(1.0, ".2e"), (1.2, "e")]
+    , testCase "reads \"(1.3 )\""  $ testReads "(1.3 )"  [(1.3, "")]
+    , testCase "reads \"((1.3))\"" $ testReads "((1.3))" [(1.3, "")]
+    , testCase "reads \" 1.3\""    $ testReads " 1.3"    [(1.0, ".3"), (1.3, "")]
     ]
 
   , testGroup "Formatting"


### PR DESCRIPTION
Fixes both the 

~~~ haskell
Prelude Data.Scientific> reads "0.0" :: [(Data.Scientific.Scientific,String)]
[(0.0,".0"),(0.0,"")]
~~~

problem and the

> `read " 8" :: Scientific` fails, while `read " 8" :: Double` succeeds

problem.