### PR TITLE
Depend on bytestring-builder for backwards compatibility

### DIFF
--- a/scientific.cabal
+++ b/scientific.cabal
@@ -60,7 +60,8 @@ flag integer-simple
   default:     False
 
 library
-  exposed-modules:     Data.Scientific
+  exposed-modules:     Data.ByteString.Builder.Scientific
+                       Data.Scientific
                        Data.Text.Lazy.Builder.Scientific
   other-modules:       Math.NumberTheory.Logarithms
                        GHC.Integer.Logarithms.Compat
@@ -69,6 +70,7 @@ library
   other-extensions:    DeriveDataTypeable, BangPatterns
   ghc-options:         -Wall
   build-depends:       base        >= 4.3   && < 4.10
+                     , bytestring  >= 0.9    && < 0.11
                      , ghc-prim
                      , deepseq     >= 1.3   && < 1.5
                      , text        >= 0.8   && < 1.3
@@ -76,6 +78,9 @@ library
                      , vector      >= 0.5   && < 0.12
                      , containers  >= 0.1   && < 0.6
                      , binary      >= 0.4.1 && < 0.9
+
+  if !impl(ghc >= 7.8)
+      build-depends: bytestring-builder >= 0.10.4 && < 0.11
 
   if flag(integer-simple)
       build-depends: integer-simple
@@ -86,10 +91,6 @@ library
   hs-source-dirs:      src
   default-language:    Haskell2010
 
-  if flag(bytestring-builder)
-    exposed-modules:   Data.ByteString.Builder.Scientific
-    build-depends:     bytestring >= 0.10 && < 0.11
-
 test-suite test-scientific
   type:             exitcode-stdio-1.0
   hs-source-dirs:   test
@@ -99,6 +100,7 @@ test-suite test-scientific
 
   build-depends: scientific
                , base             >= 4.3   && < 4.10
+               , bytestring       >= 0.9   && < 0.11
                , binary           >= 0.4.1 && < 0.9
                , tasty            >= 0.5   && < 0.12
                , tasty-ant-xml    >= 1.0   && < 1.1
@@ -109,9 +111,8 @@ test-suite test-scientific
                , QuickCheck       >= 2.5   && < 2.9
                , text             >= 0.8   && < 1.3
 
-  if flag(bytestring-builder)
-    build-depends: bytestring >= 0.10 && < 0.11
-    cpp-options: -DBYTESTRING_BUILDER
+  if !impl(ghc >= 7.8)
+      build-depends: bytestring-builder >= 0.10.4 && < 0.11
 
 benchmark bench-scientific
   type:             exitcode-stdio-1.0

--- a/src/Data/ByteString/Builder/Scientific.hs
+++ b/src/Data/ByteString/Builder/Scientific.hs
@@ -12,15 +12,8 @@ import qualified Data.Scientific as Scientific
 import Data.Text.Lazy.Builder.RealFloat (FPFormat(..))
 
 import qualified Data.ByteString.Char8 as BC8
-
-#if !MIN_VERSION_bytestring(0,10,2)
-import           Data.ByteString.Lazy.Builder (Builder, string8, char8)
-import           Data.ByteString.Lazy.Builder.ASCII (intDec)
-import           Data.ByteString.Lazy.Builder.Extras (byteStringCopy)
-#else
 import           Data.ByteString.Builder (Builder, string8, char8, intDec)
 import           Data.ByteString.Builder.Extra (byteStringCopy)
-#endif
 
 import Utils (roundTo, i2d)
 

--- a/test/test.hs
+++ b/test/test.hs
@@ -31,16 +31,9 @@ import qualified Data.Text.Lazy.Builder             as TLB (toLazyText)
 import qualified Data.Text.Lazy.Builder.Scientific  as T
 import           Numeric ( floatToDigits )
 
-#ifdef BYTESTRING_BUILDER
 import qualified Data.ByteString.Lazy.Char8         as BLC8
 import qualified Data.ByteString.Builder.Scientific as B
-
-#if !MIN_VERSION_bytestring(0,10,2)
-import qualified Data.ByteString.Lazy.Builder       as B
-#else
 import qualified Data.ByteString.Builder            as B
-#endif
-#endif
 
 main :: IO ()
 main = testMain $ testGroup "scientific"
@@ -83,12 +76,10 @@ main = testMain $ testGroup "scientific"
           TL.unpack (TLB.toLazyText $
                        T.formatScientificBuilder Scientific.Generic Nothing s)
 
-#ifdef BYTESTRING_BUILDER
       , testProperty "ByteString" $ \s ->
           formatScientific Scientific.Generic Nothing s ==
           BLC8.unpack (B.toLazyByteString $
                         B.formatScientificBuilder Scientific.Generic Nothing s)
-#endif
       ]
 
     , testProperty "formatScientific_fromFloatDigits" $ \(d::Double) ->


### PR DESCRIPTION
Currently, `scientific` conditionally exports the `Data.ByteString.Builder.Scientific` module depending on whether a recent-enough version of `bytestring` is used. Unfortunately, this means I can't use it with GHC 7.6 and older, which has caused some [build issues](https://travis-ci.org/bos/aeson/jobs/136320874#L1076) for me.

This PR uses the `bytestring-builder` compatibility package (when an old GHC version is used) to ensure that `Data.ByteString.Builder` is always available, so that it is possible to always export `Data.ByteString.Builder.Scientific`. As a bonus, this obviates the need for a lot of CPP.