### PR TITLE
Make bytestring-builder's installation conditional based on a Cabal flag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,18 +4,18 @@ sudo: false
 
 matrix:
   include:
-    #- env: CABALVER=1.16 GHCVER=7.0.4 NOTESTS=YES
+    #- env: CABALVER=1.18 GHCVER=7.0.4 NOTESTS=YES
     #  compiler: ": #GHC 7.0.4"
-    #  addons: {apt: {packages: [cabal-install-1.16,ghc-7.0.4], sources: [hvr-ghc]}}
-    #- env: CABALVER=1.16 GHCVER=7.2.2 NOTESTS=YES
+    #  addons: {apt: {packages: [cabal-install-1.18,ghc-7.0.4], sources: [hvr-ghc]}}
+    #- env: CABALVER=1.18 GHCVER=7.2.2 NOTESTS=YES
     # compiler: ": #GHC 7.2.2"
-    #  addons: {apt: {packages: [cabal-install-1.16,ghc-7.2.2], sources: [hvr-ghc]}}
-    #- env: CABALVER=1.16 GHCVER=7.4.2
+    #  addons: {apt: {packages: [cabal-install-1.18,ghc-7.2.2], sources: [hvr-ghc]}}
+    #- env: CABALVER=1.18 GHCVER=7.4.2
     #  compiler: ": #GHC 7.4.2"
-    #  addons: {apt: {packages: [cabal-install-1.16,ghc-7.4.2], sources: [hvr-ghc]}}
-    - env: CABALVER=1.16 GHCVER=7.6.3
+    #  addons: {apt: {packages: [cabal-install-1.18,ghc-7.4.2], sources: [hvr-ghc]}}
+    - env: CABALVER=1.18 GHCVER=7.6.3
       compiler: ": #GHC 7.6.3"
-      addons: {apt: {packages: [cabal-install-1.16,ghc-7.6.3], sources: [hvr-ghc]}}
+      addons: {apt: {packages: [cabal-install-1.18,ghc-7.6.3], sources: [hvr-ghc]}}
     - env: CABALVER=1.18 GHCVER=7.8.4
       compiler: ": #GHC 7.8.4"
       addons: {apt: {packages: [cabal-install-1.18,ghc-7.8.4], sources: [hvr-ghc]}}

--- a/scientific.cabal
+++ b/scientific.cabal
@@ -49,6 +49,11 @@ source-repository head
   type:     git
   location: git://github.com/basvandijk/scientific.git
 
+flag bytestring-builder
+  description: Depend on the bytestring-builder package for backwards compatibility.
+  default:     False
+  manual:      False
+
 flag integer-simple
   description: Use the integer-simple package instead of integer-gmp
   default:     False
@@ -64,7 +69,6 @@ library
   other-extensions:    DeriveDataTypeable, BangPatterns
   ghc-options:         -Wall
   build-depends:       base        >= 4.3   && < 4.10
-                     , bytestring  >= 0.9    && < 0.11
                      , ghc-prim
                      , deepseq     >= 1.3   && < 1.5
                      , text        >= 0.8   && < 1.3
@@ -73,8 +77,11 @@ library
                      , containers  >= 0.1   && < 0.6
                      , binary      >= 0.4.1 && < 0.9
 
-  if !impl(ghc >= 7.8)
-      build-depends: bytestring-builder >= 0.10.4 && < 0.11
+  if flag(bytestring-builder)
+      build-depends: bytestring         >= 0.9    && < 0.10.4
+                   , bytestring-builder >= 0.10.4 && < 0.11
+  else
+      build-depends: bytestring         >= 0.10.4 && < 0.11
 
   if flag(integer-simple)
       build-depends: integer-simple
@@ -94,7 +101,6 @@ test-suite test-scientific
 
   build-depends: scientific
                , base             >= 4.3   && < 4.10
-               , bytestring       >= 0.9   && < 0.11
                , binary           >= 0.4.1 && < 0.9
                , tasty            >= 0.5   && < 0.12
                , tasty-ant-xml    >= 1.0   && < 1.1
@@ -105,8 +111,11 @@ test-suite test-scientific
                , QuickCheck       >= 2.5   && < 2.9
                , text             >= 0.8   && < 1.3
 
-  if !impl(ghc >= 7.8)
-      build-depends: bytestring-builder >= 0.10.4 && < 0.11
+  if flag(bytestring-builder)
+      build-depends: bytestring         >= 0.9    && < 0.10.4
+                   , bytestring-builder >= 0.10.4 && < 0.11
+  else
+      build-depends: bytestring         >= 0.10.4 && < 0.11
 
 benchmark bench-scientific
   type:             exitcode-stdio-1.0


### PR DESCRIPTION
I goofed a bit when creating #41. I intended to solve the problem of making `Data.ByteString.Builder.Scientific` always available regardless of GHC version, but I did so in a rather unhygienic way. I made `scientific` depend on `bytestring-builder` conditionally if an older GHC version was used, but as @phadej [shows](https://github.com/basvandijk/scientific/pull/41#commitcomment-18096363), it's quite easy to construct a build plan in which a recent GHC version installs an old `bytestring` version.

What I should have done originally (and what this PR accomplishes) is make `bytestring-builder` conditionally installed depending on a Cabal flag. In fact, this was what was done earlier, except that manual was set to `True`, so `cabal-install` couldn't switch off the `bytestring-builder` flag if the solver deemed it unneeded.

Note that this PR bumps the minimum version of `cabal-install` required by the Travis script to 1.18, since there [have been bugs observed](https://github.com/ekmett/semigroups/issues/70) with older versions of the `cabal-install` dependency solver.