### PR TITLE
Tighten lower bound on vector

### DIFF
--- a/scientific.cabal
+++ b/scientific.cabal
@@ -73,7 +73,7 @@ library
                      , deepseq     >= 1.3   && < 1.5
                      , text        >= 0.8   && < 1.3
                      , hashable    >= 1.1.2 && < 1.3
-                     , vector      >= 0.5   && < 0.13
+                     , vector      >= 0.7   && < 0.13
                      , containers  >= 0.1   && < 0.6
                      , binary      >= 0.4.1 && < 0.9
 


### PR DESCRIPTION
versions prior to vector-0.7 result in a compile failure:

```
Preprocessing library scientific-0.3.4.9...
[5 of 7] Compiling Data.Scientific  ( src/Data/Scientific.hs, /tmp/scientific-0.3.4.9/dist-newstyle/build/x86_64-linux/ghc-7.4.2/scientific-0.3.4.9/build/Data/Scientific.o )

src/Data/Scientific.hs:580:29: Not in scope: `V.unsafeFreeze'
```
```