### PR TITLE
Tweak Haddock markup in .cabal file

### DIFF
--- a/scientific.cabal
+++ b/scientific.cabal
@@ -2,7 +2,7 @@ name:                scientific
 version:             0.3.5.2
 synopsis:            Numbers represented using scientific notation
 description:
-  @Data.Scientific@ provides the number type 'Scientific'. Scientific numbers are
+  "Data.Scientific" provides the number type 'Scientific'. Scientific numbers are
   arbitrary precision and space efficient. They are represented using
   <http://en.wikipedia.org/wiki/Scientific_notation scientific notation>.
   The implementation uses a coefficient @c :: 'Integer'@ and a base-10 exponent
@@ -25,8 +25,8 @@ description:
   @1e1000000000 :: 'Rational'@ will fill up all space and crash your
   program. Scientific works as expected:
   .
-   > > read "1e1000000000" :: Scientific
-   > 1.0e1000000000
+  >>> read "1e1000000000" :: Scientific
+  1.0e1000000000
   .
   * Also, the space usage of converting scientific numbers with huge exponents to
   @'Integral's@ (like: 'Int') or @'RealFloat's@ (like: 'Double' or 'Float')


### PR DESCRIPTION
This will make Hackage link to the "Data.Scientific" module as well as use the
REPL example style.

You can see an example here: http://hackage.haskell.org/package/cassava-0.5.1.0