### PR TITLE
Preparation for supporting GHC 8.4.1

### DIFF
--- a/scientific.cabal
+++ b/scientific.cabal
@@ -66,7 +66,7 @@ library
                        Utils
   other-extensions:    DeriveDataTypeable, BangPatterns
   ghc-options:         -Wall
-  build-depends:       base        >= 4.3   && < 4.11
+  build-depends:       base        >= 4.3   && < 4.12
                      , integer-logarithms >= 1 && <1.1
                      , deepseq     >= 1.3   && < 1.5
                      , text        >= 0.8   && < 1.3
@@ -97,7 +97,7 @@ test-suite test-scientific
   ghc-options:      -Wall
 
   build-depends: scientific
-               , base             >= 4.3   && < 4.11
+               , base             >= 4.3   && < 4.12
                , binary           >= 0.4.1 && < 0.9
                , tasty            >= 0.5   && < 1.1
                , tasty-ant-xml    >= 1.0   && < 1.2
@@ -121,5 +121,5 @@ benchmark bench-scientific
   default-language: Haskell2010
   ghc-options:      -O2
   build-depends:    scientific
-                  , base        >= 4.3   && < 4.11
+                  , base        >= 4.3   && < 4.12
                   , criterion   >= 0.5   && < 1.4


### PR DESCRIPTION
GHC 8.4.1-alpha1 was [announced](https://mail.haskell.org/pipermail/ghc-devs/2017-December/015235.html). This PR fixes compilation with this version of GHC.
