### PR TITLE
Surrounds negative numbers with parentheses when necessary

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -90,8 +90,8 @@ install:
 # any command which exits with a non-zero exit code causes the build to fail.
 script:
   # test that source-distributions can be generated
-  - (cd "." && cabal sdist)
-  - mv "."/dist/scientific-*.tar.gz ${DISTDIR}/
+  - (cd "." && cabal new-sdist)
+  - mv "."/dist-newstyle/sdist/scientific-*.tar.gz ${DISTDIR}/
   - cd ${DISTDIR} || false
   - find . -maxdepth 1 -name '*.tar.gz' -exec tar -xvf '{}' \;
   - "printf 'packages: scientific-*/*.cabal\\n' > cabal.project"

--- a/changelog
+++ b/changelog
@@ -21,6 +21,9 @@
 
 	* Make / on Scientifics slightly more efficient.
 
+	* Fix the Show instance to surround negative numbers with parentheses when
+	necessary.
+
 0.3.6.2
 	* Due to a regression introduced in 0.3.4.14 the RealFrac methods
 	and floatingOrInteger became vulnerable to a space blowup when

--- a/src/Data/Scientific/Internal.hs
+++ b/src/Data/Scientific/Internal.hs
@@ -953,11 +953,16 @@ isE c = c == 'e' || c == 'E'
 
 -- | See 'formatScientific' if you need more control over the rendering.
 instance Show Scientific where
-    show s | coefficient s < 0 = '-':showPositive (-s)
-           | otherwise         =     showPositive   s
+    showsPrec d s
+        | coefficient s < 0 = showParen (d > prefixMinusPrec) $
+               showChar '-' . showPositive (-s)
+        | otherwise         = showPositive   s
       where
-        showPositive :: Scientific -> String
-        showPositive = fmtAsGeneric . toDecimalDigits
+        prefixMinusPrec :: Int
+        prefixMinusPrec = 6
+
+        showPositive :: Scientific -> ShowS
+        showPositive = showString . fmtAsGeneric . toDecimalDigits
 
         fmtAsGeneric :: ([Int], Int) -> String
         fmtAsGeneric x@(_is, e)

--- a/test/test.hs
+++ b/test/test.hs
@@ -112,6 +112,9 @@ main = testMain $ testGroup "scientific"
 
   , testGroup "Formatting"
     [ testProperty "read . show == id" $ \s -> read (show s) === s
+    , testCase "show (Just 1)"    $ testShow (Just 1)    "Just 1.0"
+    , testCase "show (Just 0)"    $ testShow (Just 0)    "Just 0.0"
+    , testCase "show (Just (-1))" $ testShow (Just (-1)) "Just (-1.0)"
 
     , testGroup "toDecimalDigits"
       [ smallQuick "laws"
@@ -282,6 +285,9 @@ testReads inp out = reads inp @?= out
 
 testRead :: String -> Scientific -> Assertion
 testRead inp out = read inp @?= out
+
+testShow :: Maybe Scientific -> String -> Assertion
+testShow inp out = show inp @?= out
 
 testScientificP :: String -> [(Scientific, String)] -> Assertion
 testScientificP inp out = readP_to_S Scientific.scientificP inp @?= out


### PR DESCRIPTION
This behavior is consistent with Show instances of integral types in
base and allows the result of `show` to be parsed as Haskell code.
The added test used to fail and now passes:

```
    show (Just (-1)):                   FAIL
      test/test.hs:116:
      expected: "Just (-1.0)"
       but got: "Just -1.0"
```