### PR TITLE
Add Safe Haskell support

### DIFF
--- a/changelog
+++ b/changelog
@@ -1,3 +1,8 @@
+0.4.0.0
+	* Add Safe Haskell support.
+
+	* Remove unsafeFromRational from Data.Scientific exports.
+
 0.3.7.0
 	* Normalize scientific numbers on construction.
 

--- a/scientific.cabal
+++ b/scientific.cabal
@@ -1,5 +1,5 @@
 name:                scientific
-version:             0.3.7.0
+version:             0.4.0.0
 synopsis:            Numbers represented using scientific notation
 description:
   "Data.Scientific" provides the number type 'Scientific'. Scientific numbers are

--- a/src/Data/ByteString/Builder/Scientific.hs
+++ b/src/Data/ByteString/Builder/Scientific.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE CPP, OverloadedStrings #-}
+{-# LANGUAGE CPP, OverloadedStrings, Safe #-}
 
 module Data.ByteString.Builder.Scientific
     ( scientificBuilder

--- a/src/Data/Scientific.hs
+++ b/src/Data/Scientific.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE Trustworthy #-}
+
 -- |
 -- Module      :  Data.Scientific
 -- Copyright   :  Bas van Dijk 2013
@@ -58,7 +60,6 @@ module Data.Scientific
 
       -- * Conversions
       -- ** Rational
-    , unsafeFromRational
     , fromRationalRepetend
     , fromRationalRepetendLimited
     , fromRationalRepetendUnlimited

--- a/src/Data/Scientific/Internal.hs
+++ b/src/Data/Scientific/Internal.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE UnboxedTuples #-}
+{-# LANGUAGE Unsafe #-}
 {-# LANGUAGE PatternGuards #-}
 
 module Data.Scientific.Internal

--- a/src/Data/Scientific/Unsafe.hs
+++ b/src/Data/Scientific/Unsafe.hs
@@ -3,6 +3,7 @@
 module Data.Scientific.Unsafe
     ( unsafeScientificFromNormalized
     , unsafeScientificFromNonNormalized
+    , unsafeFromRational
     ) where
 
 import Data.Scientific.Internal

--- a/src/Data/Text/Lazy/Builder/Scientific.hs
+++ b/src/Data/Text/Lazy/Builder/Scientific.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE CPP, OverloadedStrings #-}
+{-# LANGUAGE CPP, OverloadedStrings, Safe #-}
 
 module Data.Text.Lazy.Builder.Scientific
     ( scientificBuilder

--- a/src/Utils.hs
+++ b/src/Utils.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE MagicHash #-}
+{-# LANGUAGE Trustworthy #-}
 {-# LANGUAGE UnboxedTuples #-}
 
 module Utils


### PR DESCRIPTION
Add Safe Haskell extensions to each file, and move unsafeFromRational from Data.Scientific to Data.Scientific.Unsafe. This arose from attempts to add Safe Haskell support to Megaparsec (see mrkkrp/megaparsec#425).