### PR TITLE
Add delayedFloatingOrInteger

### DIFF
--- a/src/Data/Scientific.hs
+++ b/src/Data/Scientific.hs
@@ -66,6 +66,7 @@ module Data.Scientific
 
       -- ** Floating & integer
     , floatingOrInteger
+    , delayedFloatingOrInteger
     , toRealFloat
     , toBoundedRealFloat
     , toBoundedInteger


### PR DESCRIPTION
I'm writing a rather dynamically typed application where I need to convert a `Scientific`, but I don't know the types to convert to until *after* I know whether the `Scientific` is floating or not. But the current interface to `floatingOrInteger` requires preselection of the types.

Happily with `-XImpredicativeTypes`, we can make a more general interface, though it has downsides, as documented in this patch.

I'd understand if this is too, say, avant garde for this library, but I thought I'd give a shot at suggesting this.