### PR TITLE
Update scientific.nix and add haskell-language-server to shell

### DIFF
--- a/scientific.nix
+++ b/scientific.nix
@@ -1,23 +1,22 @@
-{ mkDerivation, base, binary, bytestring, containers, deepseq
-, hashable, integer-gmp, integer-logarithms, QuickCheck, smallcheck, stdenv, tasty
-, tasty-ant-xml, tasty-hunit, tasty-quickcheck, tasty-smallcheck
-, text, primitive, criterion
+{ mkDerivation, base, binary, bytestring, containers, criterion
+, deepseq, hashable, integer-logarithms, lib, primitive, QuickCheck
+, smallcheck, tasty, tasty-hunit, tasty-quickcheck
+, tasty-smallcheck, text
 }:
 mkDerivation {
   pname = "scientific";
-  version = "HEAD";
+  version = "0.3.7.0";
   src = ./.;
   libraryHaskellDepends = [
-    base binary bytestring containers deepseq hashable integer-gmp
-    integer-logarithms text primitive
+    base binary bytestring containers deepseq hashable
+    integer-logarithms primitive text
   ];
   testHaskellDepends = [
-    base bytestring QuickCheck smallcheck tasty tasty-ant-xml
-    tasty-hunit tasty-quickcheck tasty-smallcheck text
-
-    criterion
+    base binary bytestring QuickCheck smallcheck tasty tasty-hunit
+    tasty-quickcheck tasty-smallcheck text
   ];
+  benchmarkHaskellDepends = [ base criterion ];
   homepage = "https://github.com/basvandijk/scientific";
   description = "Numbers represented using scientific notation";
-  license = stdenv.lib.licenses.bsd3;
+  license = lib.licenses.bsd3;
 }

--- a/shell.nix
+++ b/shell.nix
@@ -8,8 +8,13 @@ let
                       then pkgs.haskellPackages
                       else pkgs.haskell.packages.${compiler};
 
-  drv = haskellPackages.callPackage (import ./scientific.nix) {};
-
 in
-
-  if pkgs.lib.inNixShell then drv.env else drv
+    haskellPackages.shellFor {
+      packages = hpkgs: [
+        (hpkgs.callPackage (import ./scientific.nix) {})
+      ];
+      nativeBuildInputs = [
+        pkgs.haskell-language-server
+        pkgs.cabal-install
+      ];
+    }


### PR DESCRIPTION
This makes it trivial to edit the library, just open a `nix-shell` and vscode inside and you are good to go!

I removed the `inNixShell` thing, because for building the package the `default.nix` should be enough.