### PR TITLE
Make Hashable dependency optional

### DIFF
--- a/scientific.cabal
+++ b/scientific.cabal
@@ -70,6 +70,11 @@ flag integer-simple
   description: Use the integer-simple package instead of integer-gmp
   default:     False
 
+flag hashable
+  description: Add dependency on `hashable`, and add `Hashable Scientific` instance.
+  default:     True
+  manual:      True
+
 library
   exposed-modules:
     Data.ByteString.Builder.Scientific
@@ -93,7 +98,6 @@ library
     , binary              >=0.5.1
     , containers          >=0.4.2.1
     , deepseq             >=1.3.0.0
-    , hashable            >=1.2.7.0
     , integer-logarithms  >=1.0.3.1
     , primitive           >=0.7.1.0
     , text                >=1.2.3.0
@@ -105,6 +109,10 @@ library
 
   else
     build-depends: bytestring >=0.10.4 && <0.12
+
+  if flag(hashable)
+    cpp-options:   -DHASHABLE
+    build-depends: hashable            >=1.2.7.0
 
   if impl(ghc >=9.0)
     build-depends: base >=4.15

--- a/src/Data/Scientific/Internal.hs
+++ b/src/Data/Scientific/Internal.hs
@@ -62,7 +62,9 @@ import           Control.DeepSeq              (NFData, rnf)
 import           Data.Binary                  (Binary, get, put)
 import           Data.Char                    (intToDigit, ord)
 import           Data.Data                    (Data)
+#ifdef HASHABLE
 import           Data.Hashable                (Hashable(..))
+#endif
 import           Data.Int                     (Int8, Int16, Int32, Int64)
 import qualified Data.Map            as M     (Map, empty, insert, lookup)
 import           Data.Ratio                   ((%), numerator, denominator)
@@ -160,11 +162,13 @@ unsafeScientificFromNonNormalized c z e = Scientific (c `quotInteger` magnitude 
 instance NFData Scientific where
     rnf (Scientific _ _) = ()
 
+#ifdef HASHABLE
 -- | A hash can be safely calculated from a @Scientific@. No magnitude @10^e@ is
 -- calculated so there's no risk of a blowup in space or time when hashing
 -- scientific numbers coming from untrusted sources.
 instance Hashable Scientific where
     hashWithSalt salt (Scientific c e) = salt `hashWithSalt` c `hashWithSalt` e
+#endif
 
 -- | Note that in the future I intend to change the type of the 'base10Exponent'
 -- from @Int@ to @Integer@. To be forward compatible the @Binary@ instance


### PR DESCRIPTION
This is a dependency purely for writing an instance, so it should be optional IMO.

A better solution would be to put it in a cabal sublibrary, but a flag will do. I've made it default to true, but I recommend defaulting it to false on the next major release (or putting it in a sublibrary).